### PR TITLE
Include config_declaration.yaml into MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include *requirements*.txt
 include CHANGELOG
 include LICENSE
 include README.rst
+include ckanext/xloader/config_declaration.yaml
 recursive-include ckanext/xloader/templates *.html

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='1.0.0',
+    version='1.0.1',
 
     description='Express Loader - quickly load data into CKAN DataStore''',
     long_description=long_description,


### PR DESCRIPTION
We need to include the new `config_declaration.yaml` file into the MANIFEST file.

```
    return wrapper(plugin)
  File "/usr/lib/ckan/venv/lib/python3.8/site-packages/ckan/plugins/blanket.py", line 443, in wrapper
    key.implement(plugin, subject)
  File "/usr/lib/ckan/venv/lib/python3.8/site-packages/ckan/plugins/blanket.py", line 198, in implement
    subject = self.get_subject(plugin)
  File "/usr/lib/ckan/venv/lib/python3.8/site-packages/ckan/plugins/blanket.py", line 177, in get_subject
    return _mapping[self].extract_subject(plugin)
  File "/usr/lib/ckan/venv/lib/python3.8/site-packages/ckan/plugins/blanket.py", line 239, in _declaration_file_extractor
    raise FileNotFoundError("config_declaration.EXT")
FileNotFoundError: config_declaration.EXT
```