### PR TITLE
Implement a new Interface function for datastore_before_update

### DIFF
--- a/ckanext/xloader/interfaces.py
+++ b/ckanext/xloader/interfaces.py
@@ -47,3 +47,30 @@ class IXloader(Interface):
             the resource that was uploaded
         """
         pass
+
+    def datastore_before_update(self, resource_id, existing_info, new_headers):
+        """ Called by the loader just before it is about to modify the
+        DataStore table for a resource (truncate, drop+recreate, or create).
+        It allows plugins to inspect the difference between the current
+        DataStore columns and the ones detected in the incoming file, for
+        example to log an activity when columns are added, removed or
+        renamed.
+
+        :param resource_id: the ID of the resource whose DataStore table is
+            about to be updated.
+        :type resource_id: string
+
+        :param existing_info: a mapping of ``{field_id: info_dict}`` built
+            from the existing DataStore table's Data Dictionary, or ``None``
+            if the DataStore table does not yet exist.
+        :type existing_info: dict or None
+
+        :param new_headers: the list of field dicts that will be written to
+            the DataStore. Each dict has at least an ``id`` and ``type``
+            key, and may include an ``info`` dict for fields that already
+            existed.
+        :type new_headers: list of dicts
+
+        The return value is ignored.
+        """
+        pass

--- a/ckanext/xloader/interfaces.py
+++ b/ckanext/xloader/interfaces.py
@@ -48,7 +48,7 @@ class IXloader(Interface):
         """
         pass
 
-    def datastore_before_update(self, resource_id, existing_info, new_headers):
+    def datastore_before_update(self, resource_id, existing_fields, new_headers):
         """ Called by the loader just before it is about to modify the
         DataStore table for a resource (truncate, drop+recreate, or create).
         It allows plugins to inspect the difference between the current
@@ -56,14 +56,25 @@ class IXloader(Interface):
         example to log an activity when columns are added, removed or
         renamed.
 
+        Both ``existing_fields`` and ``new_headers`` are lists of field
+        dicts that contain at least an ``id`` key, so a plugin can compute
+        the diff symmetrically::
+
+            old_ids = {f['id'] for f in existing_fields or []}
+            new_ids = {h['id'] for h in new_headers}
+            added = new_ids - old_ids
+            removed = old_ids - new_ids
+
         :param resource_id: the ID of the resource whose DataStore table is
             about to be updated.
         :type resource_id: string
 
-        :param existing_info: a mapping of ``{field_id: info_dict}`` built
-            from the existing DataStore table's Data Dictionary, or ``None``
-            if the DataStore table does not yet exist.
-        :type existing_info: dict or None
+        :param existing_fields: the current columns of the DataStore table
+            (the internal ``_id`` column is excluded), or ``None`` if the
+            DataStore table does not yet exist. Each dict contains at least
+            ``id`` and ``type`` and may include ``info`` for fields with a
+            Data Dictionary entry.
+        :type existing_fields: list of dicts or None
 
         :param new_headers: the list of field dicts that will be written to
             the DataStore. Each dict has at least an ``id`` and ``type``

--- a/ckanext/xloader/interfaces.py
+++ b/ckanext/xloader/interfaces.py
@@ -82,14 +82,10 @@ class IXloader(Interface):
             existed.
         :type new_headers: list of dicts
 
-        .. warning::
-
-            The ``existing_fields`` and ``new_headers`` lists are the
-            same objects that the loader will use after this hook returns.
-            Mutating them (e.g. adding, removing or renaming fields) will
-            affect the subsequent DataStore operation.  This hook is
-            intended for **read-only observation**; modify the lists only
-            if you fully understand the downstream consequences.
+        The ``existing_fields`` and ``new_headers`` lists are the same
+        objects the loader will use after this hook returns, so mutating
+        them (e.g. adding, removing or renaming fields) will affect the
+        subsequent DataStore operation.
 
         The return value is ignored.
         """

--- a/ckanext/xloader/interfaces.py
+++ b/ckanext/xloader/interfaces.py
@@ -82,6 +82,15 @@ class IXloader(Interface):
             existed.
         :type new_headers: list of dicts
 
+        .. warning::
+
+            The ``existing_fields`` and ``new_headers`` lists are the
+            same objects that the loader will use after this hook returns.
+            Mutating them (e.g. adding, removing or renaming fields) will
+            affect the subsequent DataStore operation.  This hook is
+            intended for **read-only observation**; modify the lists only
+            if you fully understand the downstream consequences.
+
         The return value is ignored.
         """
         pass

--- a/ckanext/xloader/interfaces.py
+++ b/ckanext/xloader/interfaces.py
@@ -82,10 +82,11 @@ class IXloader(Interface):
             existed.
         :type new_headers: list of dicts
 
-        The ``existing_fields`` and ``new_headers`` lists are the same
-        objects the loader will use after this hook returns, so mutating
-        them (e.g. adding, removing or renaming fields) will affect the
-        subsequent DataStore operation.
+        The ``new_headers`` param is the same list the loader will use after the
+        hook returns, so mutating it (adding, removing, renaming fields)
+        will affect the subsequent DataStore operation.
+        The ``existing_fields`` is a snapshot with the internal ``_id`` column
+        excluded and should be treated as read-only.
 
         The return value is ignored.
         """

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -384,16 +384,16 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', allow_type_guessing
         else:
             logger.info('Deleting "%s" from DataStore.', resource_id)
             delete_datastore_resource(resource_id)
-            # if file structure has changed,
-            # and it wasn't just from a Data Dictionary override,
-            # then we need to re-guess types
-            if allow_type_guessing and fields_match == FieldMatch.MISMATCH:
-                raise LoaderError("File structure has changed, reverting to Tabulator")
             _notify_datastore_before_update(
                 resource_id=resource_id,
                 existing_fields=existing_fields,
                 new_headers=fields,
             )
+            # if file structure has changed,
+            # and it wasn't just from a Data Dictionary override,
+            # then we need to re-guess types
+            if allow_type_guessing and fields_match == FieldMatch.MISMATCH:
+                raise LoaderError("File structure has changed, reverting to Tabulator")
     else:
         fields = [
             {'id': header_name,

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -24,14 +24,19 @@ from .parser import CSV_SAMPLE_LINES, TypeConverter
 from .utils import cleanup_temp_file, datastore_resource_exists, headers_guess, type_guess
 
 
-def _notify_datastore_before_update(resource_id, existing_info, new_headers):
+def _notify_datastore_before_update(resource_id, existing_fields, new_headers):
     """Notify IXloader plugins that the DataStore table for ``resource_id``
     is about to change. See ``IXloader.datastore_before_update``.
+
+    The internal ``_id`` column is stripped from ``existing_fields`` so
+    consumers only see user-visible columns.
     """
+    if existing_fields is not None:
+        existing_fields = [f for f in existing_fields if f.get('id') != '_id']
     for plugin in p.PluginImplementations(IXloader):
         plugin.datastore_before_update(
             resource_id=resource_id,
-            existing_info=existing_info,
+            existing_fields=existing_fields,
             new_headers=new_headers,
         )
 
@@ -369,7 +374,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', allow_type_guessing
         '''
         fields_match = _fields_match(fields, existing_fields, logger)
         if fields_match == FieldMatch.EXACT_MATCH:
-            _notify_datastore_before_update(resource_id, existing_info, fields)
+            _notify_datastore_before_update(resource_id, existing_fields, fields)
             logger.info('Clearing records for "%s" from DataStore.', resource_id)
             _clear_datastore_resource(resource_id)
         else:
@@ -380,7 +385,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', allow_type_guessing
             # then we need to re-guess types
             if allow_type_guessing and fields_match == FieldMatch.MISMATCH:
                 raise LoaderError("File structure has changed, reverting to Tabulator")
-            _notify_datastore_before_update(resource_id, existing_info, fields)
+            _notify_datastore_before_update(resource_id, existing_fields, fields)
     else:
         fields = [
             {'id': header_name,
@@ -606,7 +611,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
         Otherwise 'datastore_create' will append to the existing datastore.
         And if the fields have significantly changed, it may also fail.
         '''
-        _notify_datastore_before_update(resource_id, existing_info, headers_dicts)
+        _notify_datastore_before_update(resource_id, existing_fields, headers_dicts)
         if existing:
             if _fields_match(headers_dicts, existing_fields, logger) == FieldMatch.EXACT_MATCH:
                 logger.info('Clearing records for "%s" from DataStore.', resource_id)

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -18,9 +18,22 @@ import sqlalchemy as sa
 
 import ckan.plugins as p
 
+from .interfaces import IXloader
 from .job_exceptions import FileCouldNotBeLoadedError, LoaderError
 from .parser import CSV_SAMPLE_LINES, TypeConverter
 from .utils import cleanup_temp_file, datastore_resource_exists, headers_guess, type_guess
+
+
+def _notify_datastore_before_update(resource_id, existing_info, new_headers):
+    """Notify IXloader plugins that the DataStore table for ``resource_id``
+    is about to change. See ``IXloader.datastore_before_update``.
+    """
+    for plugin in p.PluginImplementations(IXloader):
+        plugin.datastore_before_update(
+            resource_id=resource_id,
+            existing_info=existing_info,
+            new_headers=new_headers,
+        )
 
 from ckan.plugins.toolkit import config
 
@@ -356,6 +369,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', allow_type_guessing
         '''
         fields_match = _fields_match(fields, existing_fields, logger)
         if fields_match == FieldMatch.EXACT_MATCH:
+            _notify_datastore_before_update(resource_id, existing_info, fields)
             logger.info('Clearing records for "%s" from DataStore.', resource_id)
             _clear_datastore_resource(resource_id)
         else:
@@ -366,6 +380,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', allow_type_guessing
             # then we need to re-guess types
             if allow_type_guessing and fields_match == FieldMatch.MISMATCH:
                 raise LoaderError("File structure has changed, reverting to Tabulator")
+            _notify_datastore_before_update(resource_id, existing_info, fields)
     else:
         fields = [
             {'id': header_name,
@@ -590,6 +605,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
         Otherwise 'datastore_create' will append to the existing datastore.
         And if the fields have significantly changed, it may also fail.
         '''
+        _notify_datastore_before_update(resource_id, existing_info, headers_dicts)
         if existing:
             if _fields_match(headers_dicts, existing_fields, logger) == FieldMatch.EXACT_MATCH:
                 logger.info('Clearing records for "%s" from DataStore.', resource_id)

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -374,7 +374,11 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', allow_type_guessing
         '''
         fields_match = _fields_match(fields, existing_fields, logger)
         if fields_match == FieldMatch.EXACT_MATCH:
-            _notify_datastore_before_update(resource_id, existing_fields, fields)
+            _notify_datastore_before_update(
+                resource_id=resource_id,
+                existing_fields=existing_fields,
+                new_headers=fields,
+            )
             logger.info('Clearing records for "%s" from DataStore.', resource_id)
             _clear_datastore_resource(resource_id)
         else:
@@ -385,14 +389,22 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', allow_type_guessing
             # then we need to re-guess types
             if allow_type_guessing and fields_match == FieldMatch.MISMATCH:
                 raise LoaderError("File structure has changed, reverting to Tabulator")
-            _notify_datastore_before_update(resource_id, existing_fields, fields)
+            _notify_datastore_before_update(
+                resource_id=resource_id,
+                existing_fields=existing_fields,
+                new_headers=fields,
+            )
     else:
         fields = [
             {'id': header_name,
              'type': 'text',
              'strip_extra_white': True}
             for header_name in headers]
-        _notify_datastore_before_update(resource_id, None, fields)
+        _notify_datastore_before_update(
+            resource_id=resource_id,
+            existing_fields=None,
+            new_headers=fields,
+        )
 
     logger.info('Fields: %s', fields)
 
@@ -611,7 +623,11 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
         Otherwise 'datastore_create' will append to the existing datastore.
         And if the fields have significantly changed, it may also fail.
         '''
-        _notify_datastore_before_update(resource_id, existing_fields, headers_dicts)
+        _notify_datastore_before_update(
+            resource_id=resource_id,
+            existing_fields=existing_fields,
+            new_headers=headers_dicts,
+        )
         if existing:
             if _fields_match(headers_dicts, existing_fields, logger) == FieldMatch.EXACT_MATCH:
                 logger.info('Clearing records for "%s" from DataStore.', resource_id)

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -387,6 +387,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', allow_type_guessing
              'type': 'text',
              'strip_extra_white': True}
             for header_name in headers]
+        _notify_datastore_before_update(resource_id, None, fields)
 
     logger.info('Fields: %s', fields)
 

--- a/ckanext/xloader/tests/samples/simple2.csv
+++ b/ckanext/xloader/tests/samples/simple2.csv
@@ -1,0 +1,7 @@
+date,temperature,city
+2011-01-01,1,Galway
+2011-01-02,-1,Galway
+2011-01-03,0,Galway
+2011-01-01,6,Berkeley
+2011-01-02,8,Berkeley
+2011-01-03,5,Berkeley

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -1114,10 +1114,10 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
             )
 
         notify.assert_called_once()
-        resource_id, existing_fields, new_headers = notify.call_args.args
-        assert resource_id == resource['id']
-        assert not existing_fields
-        assert [h['id'] for h in new_headers] == ['date', 'temperature', 'place']
+        kwargs = notify.call_args.kwargs
+        assert kwargs['resource_id'] == resource['id']
+        assert not kwargs['existing_fields']
+        assert [h['id'] for h in kwargs['new_headers']] == ['date', 'temperature', 'place']
 
     def test_fires_on_reload_same_columns(self):
         """ Reload with the same file: existing_fields and new_headers
@@ -1142,10 +1142,10 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
             )
 
         notify.assert_called_once()
-        called_resource_id, existing_fields, new_headers = notify.call_args.args
-        assert called_resource_id == resource_id
-        assert [f['id'] for f in existing_fields] == ['date', 'temperature', 'place']
-        assert [h['id'] for h in new_headers] == ['date', 'temperature', 'place']
+        kwargs = notify.call_args.kwargs
+        assert kwargs['resource_id'] == resource_id
+        assert [f['id'] for f in kwargs['existing_fields']] == ['date', 'temperature', 'place']
+        assert [h['id'] for h in kwargs['new_headers']] == ['date', 'temperature', 'place']
 
     def test_fires_on_reload_with_changed_columns(self):
         """ Reload the resource with a renamed column (place -> city) and
@@ -1170,11 +1170,11 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
                 logger=logger,
             )
         notify.assert_called_once()
-        called_resource_id, existing_fields, new_headers = notify.call_args.args
-        assert called_resource_id == resource_id
+        kwargs = notify.call_args.kwargs
+        assert kwargs['resource_id'] == resource_id
 
-        old_ids = [f['id'] for f in existing_fields]
-        new_ids = [h['id'] for h in new_headers]
+        old_ids = [f['id'] for f in kwargs['existing_fields']]
+        new_ids = [h['id'] for h in kwargs['new_headers']]
         assert old_ids == ['date', 'temperature', 'place']
         assert new_ids == ['date', 'temperature', 'city']
 
@@ -1189,10 +1189,10 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
             )
 
         notify.assert_called_once()
-        resource_id, existing_fields, new_headers = notify.call_args.args
-        assert resource_id == resource['id']
-        assert not existing_fields
-        assert [h['id'] for h in new_headers] == ['date', 'temperature', 'place']
+        kwargs = notify.call_args.kwargs
+        assert kwargs['resource_id'] == resource['id']
+        assert not kwargs['existing_fields']
+        assert [h['id'] for h in kwargs['new_headers']] == ['date', 'temperature', 'place']
 
 
 class TestLoadTabulator(TestLoadBase):

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -1097,7 +1097,7 @@ class TestLoadUnhandledTypes(TestLoadBase):
 
 class TestDatastoreBeforeUpdateHook(TestLoadBase):
     """ Verify that loader.load_csv / loader.load_table invoke
-    IXloader.datastore_before_update with the documented payload shape
+    IXloader.datastore_before_update with the documented payload shape.
     """
 
     def test_fires_on_new_table_with_no_existing_info(self):

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -1169,7 +1169,6 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
                 mimetype="text/csv",
                 logger=logger,
             )
-
         notify.assert_called_once()
         called_resource_id, existing_fields, new_headers = notify.call_args.args
         assert called_resource_id == resource_id

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -1113,13 +1113,14 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
         notify.assert_called_once()
         resource_id, existing_info, new_headers = notify.call_args.args
         assert resource_id == resource['id']
-        assert existing_info is None
+        assert not existing_info
         assert [h['id'] for h in new_headers] == ['date', 'temperature', 'place']
 
     def test_fires_on_reload_with_existing_info(self):
         resource = factories.Resource()
         resource_id = resource['id']
-        # First load populates the datastore.
+        # First load populates the datastore. No 'info' is set on the fields
+        # during this load, so on reload existing_info must be an empty dict.
         loader.load_csv(
             get_sample_filepath("simple.csv"),
             resource_id=resource_id,
@@ -1139,9 +1140,36 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
         notify.assert_called_once()
         called_resource_id, existing_info, new_headers = notify.call_args.args
         assert called_resource_id == resource_id
-        # existing_info is a dict (possibly empty) when the table exists.
-        assert isinstance(existing_info, dict)
+        assert not existing_info
         assert [h['id'] for h in new_headers] == ['date', 'temperature', 'place']
+
+    def test_fires_on_reload_with_changed_columns(self):
+        """ Reload the resource with a renamed column (place -> city) and
+        verify the hook sees the new column names BEFORE the DataStore is
+        updated. This is the signal downstream plugins use to log a
+        'columns changed' activity.
+        """
+        resource = factories.Resource()
+        resource_id = resource['id']
+        loader.load_csv(
+            get_sample_filepath("simple.csv"),
+            resource_id=resource_id,
+            mimetype="text/csv",
+            logger=logger,
+        )
+
+        with mock.patch.object(loader, '_notify_datastore_before_update') as notify:
+            loader.load_csv(
+                get_sample_filepath("simple2.csv"),
+                resource_id=resource_id,
+                mimetype="text/csv",
+                logger=logger,
+            )
+
+        notify.assert_called_once()
+        called_resource_id, _, new_headers = notify.call_args.args
+        assert called_resource_id == resource_id
+        assert [h['id'] for h in new_headers] == ['date', 'temperature', 'city']
 
     def test_fires_for_load_table(self):
         resource = factories.Resource()
@@ -1156,7 +1184,7 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
         notify.assert_called_once()
         resource_id, existing_info, new_headers = notify.call_args.args
         assert resource_id == resource['id']
-        assert existing_info is None
+        assert not existing_info
         assert [h['id'] for h in new_headers] == ['date', 'temperature', 'place']
 
 

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -1100,7 +1100,10 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
     IXloader.datastore_before_update with the documented payload shape.
     """
 
-    def test_fires_on_new_table_with_no_existing_info(self):
+    def test_fires_on_new_table(self):
+        """ First load of a resource: no prior DataStore table, so
+        existing_fields is None and new_headers reflects the file columns.
+        """
         resource = factories.Resource()
         with mock.patch.object(loader, '_notify_datastore_before_update') as notify:
             loader.load_csv(
@@ -1111,16 +1114,18 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
             )
 
         notify.assert_called_once()
-        resource_id, existing_info, new_headers = notify.call_args.args
+        resource_id, existing_fields, new_headers = notify.call_args.args
         assert resource_id == resource['id']
-        assert not existing_info
+        assert not existing_fields
         assert [h['id'] for h in new_headers] == ['date', 'temperature', 'place']
 
-    def test_fires_on_reload_with_existing_info(self):
+    def test_fires_on_reload_same_columns(self):
+        """ Reload with the same file: existing_fields and new_headers
+        expose the same column ids, so a consumer computing
+        ``set(existing) ^ set(new)`` sees no diff.
+        """
         resource = factories.Resource()
         resource_id = resource['id']
-        # First load populates the datastore. No 'info' is set on the fields
-        # during this load, so on reload existing_info must be an empty dict.
         loader.load_csv(
             get_sample_filepath("simple.csv"),
             resource_id=resource_id,
@@ -1128,7 +1133,6 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
             logger=logger,
         )
 
-        # Patch only around the reload so we capture just that call.
         with mock.patch.object(loader, '_notify_datastore_before_update') as notify:
             loader.load_csv(
                 get_sample_filepath("simple.csv"),
@@ -1138,16 +1142,16 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
             )
 
         notify.assert_called_once()
-        called_resource_id, existing_info, new_headers = notify.call_args.args
+        called_resource_id, existing_fields, new_headers = notify.call_args.args
         assert called_resource_id == resource_id
-        assert not existing_info
+        assert [f['id'] for f in existing_fields] == ['date', 'temperature', 'place']
         assert [h['id'] for h in new_headers] == ['date', 'temperature', 'place']
 
     def test_fires_on_reload_with_changed_columns(self):
         """ Reload the resource with a renamed column (place -> city) and
-        verify the hook sees the new column names BEFORE the DataStore is
-        updated. This is the signal downstream plugins use to log a
-        'columns changed' activity.
+        verify the hook exposes both sides BEFORE the DataStore is updated,
+        so downstream plugins can diff them and log a 'columns changed'
+        activity.
         """
         resource = factories.Resource()
         resource_id = resource['id']
@@ -1167,9 +1171,13 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
             )
 
         notify.assert_called_once()
-        called_resource_id, _, new_headers = notify.call_args.args
+        called_resource_id, existing_fields, new_headers = notify.call_args.args
         assert called_resource_id == resource_id
-        assert [h['id'] for h in new_headers] == ['date', 'temperature', 'city']
+
+        old_ids = [f['id'] for f in existing_fields]
+        new_ids = [h['id'] for h in new_headers]
+        assert old_ids == ['date', 'temperature', 'place']
+        assert new_ids == ['date', 'temperature', 'city']
 
     def test_fires_for_load_table(self):
         resource = factories.Resource()
@@ -1182,9 +1190,9 @@ class TestDatastoreBeforeUpdateHook(TestLoadBase):
             )
 
         notify.assert_called_once()
-        resource_id, existing_info, new_headers = notify.call_args.args
+        resource_id, existing_fields, new_headers = notify.call_args.args
         assert resource_id == resource['id']
-        assert not existing_info
+        assert not existing_fields
         assert [h['id'] for h in new_headers] == ['date', 'temperature', 'place']
 
 

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 import os
+from unittest import mock
 import pytest
 import six
 import sqlalchemy as sa
@@ -1092,6 +1093,71 @@ class TestLoadUnhandledTypes(TestLoadBase):
             '_full_text',
             'UTF-8'
         ]
+
+
+class TestDatastoreBeforeUpdateHook(TestLoadBase):
+    """ Verify that loader.load_csv / loader.load_table invoke
+    IXloader.datastore_before_update with the documented payload shape
+    """
+
+    def test_fires_on_new_table_with_no_existing_info(self):
+        resource = factories.Resource()
+        with mock.patch.object(loader, '_notify_datastore_before_update') as notify:
+            loader.load_csv(
+                get_sample_filepath("simple.csv"),
+                resource_id=resource['id'],
+                mimetype="text/csv",
+                logger=logger,
+            )
+
+        notify.assert_called_once()
+        resource_id, existing_info, new_headers = notify.call_args.args
+        assert resource_id == resource['id']
+        assert existing_info is None
+        assert [h['id'] for h in new_headers] == ['date', 'temperature', 'place']
+
+    def test_fires_on_reload_with_existing_info(self):
+        resource = factories.Resource()
+        resource_id = resource['id']
+        # First load populates the datastore.
+        loader.load_csv(
+            get_sample_filepath("simple.csv"),
+            resource_id=resource_id,
+            mimetype="text/csv",
+            logger=logger,
+        )
+
+        # Patch only around the reload so we capture just that call.
+        with mock.patch.object(loader, '_notify_datastore_before_update') as notify:
+            loader.load_csv(
+                get_sample_filepath("simple.csv"),
+                resource_id=resource_id,
+                mimetype="text/csv",
+                logger=logger,
+            )
+
+        notify.assert_called_once()
+        called_resource_id, existing_info, new_headers = notify.call_args.args
+        assert called_resource_id == resource_id
+        # existing_info is a dict (possibly empty) when the table exists.
+        assert isinstance(existing_info, dict)
+        assert [h['id'] for h in new_headers] == ['date', 'temperature', 'place']
+
+    def test_fires_for_load_table(self):
+        resource = factories.Resource()
+        with mock.patch.object(loader, '_notify_datastore_before_update') as notify:
+            loader.load_table(
+                get_sample_filepath("simple.xls"),
+                resource_id=resource['id'],
+                mimetype="xls",
+                logger=logger,
+            )
+
+        notify.assert_called_once()
+        resource_id, existing_info, new_headers = notify.call_args.args
+        assert resource_id == resource['id']
+        assert existing_info is None
+        assert [h['id'] for h in new_headers] == ['date', 'temperature', 'place']
 
 
 class TestLoadTabulator(TestLoadBase):


### PR DESCRIPTION
Adding the `datastore_before_update` hook to `IXloader`
I need to hook into the datastore updates to detect field changes
                                                                                
This PR adds a new optional method to the IXloader interface so plugins can observe schema changes before XLoader modifies the DataStore table.
                                                                                                                                                                                      
The `datastore_before_update` call includes:
  - existing_fields: list of current DataStore field dicts (each has id, type, and optionally info), or None if the table does not yet exist. The internal `_id` column is stripped.
  - new_headers: list of field dicts about to be written.

 - [x] tests added. Ran [here](https://github.com/avdata99/ckanext-xloader/actions/runs/24473976023) because of this repo permission
